### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(Modplug REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/..
+include_directories(${KODI_INCLUDE_DIR}/..
                     ${MODPLUG_INCLUDE_DIRS})
 
 set(MODPLUG_SOURCES src/ModplugCodec.cpp)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-audiodecoder-modplug
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), cmake,
-               kodi-addon-dev, libkodiplatform-dev (>= 16.0.0), libmodplug-dev
+               kodi-addon-dev, libmodplug-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.modplug binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.