### PR TITLE
Added patch for deprecated C++17 "register" declaration keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-addon-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/depends/common/modplug/0001-C++17_deprecated.patch
+++ b/depends/common/modplug/0001-C++17_deprecated.patch
@@ -1,0 +1,21 @@
+diff -Nru libmodplug-0.8.9.0.ori/src/fastmix.cpp libmodplug-0.8.9.0/src/fastmix.cpp
+--- libmodplug-0.8.9.0.ori/src/fastmix.cpp	2017-04-24 15:10:17.000000000 +0200
++++ libmodplug-0.8.9.0/src/fastmix.cpp	2020-10-03 21:10:39.662270690 +0200
+@@ -288,7 +288,7 @@
+ // MIXING MACROS
+ // ----------------------------------------------------------------------------
+ #define SNDMIX_BEGINSAMPLELOOP8\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed char *p = (signed char *)(pChn->pCurrentSample+pChn->nPos);\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\
+@@ -296,7 +296,7 @@
+ 	do {
+ 
+ #define SNDMIX_BEGINSAMPLELOOP16\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed short *p = (signed short *)(pChn->pCurrentSample+(pChn->nPos*2));\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\

--- a/depends/osx/modplug/0001-C++17_deprecated.patch
+++ b/depends/osx/modplug/0001-C++17_deprecated.patch
@@ -1,0 +1,21 @@
+diff -Nru libmodplug-0.8.9.0.ori/src/fastmix.cpp libmodplug-0.8.9.0/src/fastmix.cpp
+--- libmodplug-0.8.9.0.ori/src/fastmix.cpp	2017-04-24 15:10:17.000000000 +0200
++++ libmodplug-0.8.9.0/src/fastmix.cpp	2020-10-03 21:10:39.662270690 +0200
+@@ -288,7 +288,7 @@
+ // MIXING MACROS
+ // ----------------------------------------------------------------------------
+ #define SNDMIX_BEGINSAMPLELOOP8\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed char *p = (signed char *)(pChn->pCurrentSample+pChn->nPos);\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\
+@@ -296,7 +296,7 @@
+ 	do {
+ 
+ #define SNDMIX_BEGINSAMPLELOOP16\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed short *p = (signed short *)(pChn->pCurrentSample+(pChn->nPos*2));\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\

--- a/depends/windows/modplug/0003-C++17_deprecated.patch
+++ b/depends/windows/modplug/0003-C++17_deprecated.patch
@@ -1,0 +1,21 @@
+diff -Nru libmodplug-0.8.9.0.ori/src/fastmix.cpp libmodplug-0.8.9.0/src/fastmix.cpp
+--- libmodplug-0.8.9.0.ori/src/fastmix.cpp	2017-04-24 15:10:17.000000000 +0200
++++ libmodplug-0.8.9.0/src/fastmix.cpp	2020-10-03 21:10:39.662270690 +0200
+@@ -288,7 +288,7 @@
+ // MIXING MACROS
+ // ----------------------------------------------------------------------------
+ #define SNDMIX_BEGINSAMPLELOOP8\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed char *p = (signed char *)(pChn->pCurrentSample+pChn->nPos);\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\
+@@ -296,7 +296,7 @@
+ 	do {
+ 
+ #define SNDMIX_BEGINSAMPLELOOP16\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed short *p = (signed short *)(pChn->pCurrentSample+(pChn->nPos*2));\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\

--- a/depends/windowsstore/modplug/0003-C++17_deprecated.patch
+++ b/depends/windowsstore/modplug/0003-C++17_deprecated.patch
@@ -1,0 +1,21 @@
+diff -Nru libmodplug-0.8.9.0.ori/src/fastmix.cpp libmodplug-0.8.9.0/src/fastmix.cpp
+--- libmodplug-0.8.9.0.ori/src/fastmix.cpp	2017-04-24 15:10:17.000000000 +0200
++++ libmodplug-0.8.9.0/src/fastmix.cpp	2020-10-03 21:10:39.662270690 +0200
+@@ -288,7 +288,7 @@
+ // MIXING MACROS
+ // ----------------------------------------------------------------------------
+ #define SNDMIX_BEGINSAMPLELOOP8\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed char *p = (signed char *)(pChn->pCurrentSample+pChn->nPos);\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\
+@@ -296,7 +296,7 @@
+ 	do {
+ 
+ #define SNDMIX_BEGINSAMPLELOOP16\
+-	register MODCHANNEL * const pChn = pChannel;\
++	MODCHANNEL * const pChn = pChannel;\
+ 	nPos = pChn->nPosLo;\
+ 	const signed short *p = (signed short *)(pChn->pCurrentSample+(pChn->nPos*2));\
+ 	if (pChn->dwFlags & CHN_STEREO) p += pChn->nPos;\


### PR DESCRIPTION
C++17 completely drops register keyword