### PR TITLE
[Matrix|N*] mark addon as deprecated, copyright year increase and cleanup

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -1,0 +1,46 @@
+name: Sync addon metadata translations
+
+on:
+  push:
+    branches: [ Matrix, Nexus ]
+    paths:
+      - '**addon.xml'
+      - '**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'xbmc/audiodecoder.modplug'
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: project
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/xbmc/sync_addon_metadata_translations.git
+
+      - name: Run sync-addon-metadata-translations
+        run: |
+          sync-addon-metadata-translations
+        working-directory: ./project
+
+      - name: Create PR for sync-addon-metadata-translations changes
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Sync of addon metadata translations
+          title: Sync of addon metadata translations
+          body: Sync of addon metadata translations triggered by ${{ github.sha }}
+          branch: amt-sync
+          delete-branch: true
+          path: ./project
+          reviewers: gade01

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for tracker module files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.modplug.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.modplug/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.modplug?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=7&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.modplug/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.modplug/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.modplug?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-modplug?branch=Matrix) -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a [Kodi](https://kodi.tv) audio decoder addon for tracker module files.
 
+> **NOTE:** It is recommended to use ["OpenMPT Audio Decoder"](https://github.com/xbmc/audiodecoder.openmpt) addon instead of this one. However, but still usable here.
+
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.modplug?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=7&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.modplug/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.modplug/branches/)

--- a/audiodecoder.modplug/addon.xml.in
+++ b/audiodecoder.modplug/addon.xml.in
@@ -13,8 +13,8 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="de_DE">Modplug Audio Decoder</summary>
     <summary lang="en_GB">Modplug Audio Decoder</summary>
-    <description lang="de_DE">Spielt MOD-Dateien und einige andere Formate ab.[CR][CR]Es wird empfohlen, anstelle dieses Addons "OpenMPT Audio Decoder" zu verwenden.</description>
-    <description lang="en_GB">Plays MOD files and few other formats.[CR][CR]It is recommended to use "OpenMPT Audio Decoder" addon instead of this one.</description>
+    <description lang="de_DE">Spielt MOD-Dateien und einige andere Formate ab.[CR][CR]Es wird empfohlen, anstelle dieses Addons &quot;OpenMPT Audio Decoder&quot; zu verwenden.</description>
+    <description lang="en_GB">Plays MOD files and few other formats.[CR][CR]It is recommended to use &quot;OpenMPT Audio Decoder&quot; addon instead of this one.</description>
     <lifecyclestate type="deprecated" lang="de_DE">Ersetzt durch das Addon audiodecoder.openmpt! Aber hier auch noch verwendbar.</lifecyclestate>
     <lifecyclestate type="deprecated" lang="en_GB">Replaced by audiodecoder.openmpt addon! However, but still usable here.</lifecyclestate>
     <platform>@PLATFORM@</platform>

--- a/audiodecoder.modplug/addon.xml.in
+++ b/audiodecoder.modplug/addon.xml.in
@@ -19,6 +19,8 @@ Es wird empfohlen, anstelle dieses Addons "OpenMPT Audio Decoder" zu verwenden.<
     <description lang="en_GB">Plays MOD files and few other formats.
 
 It is recommended to use "OpenMPT Audio Decoder" addon instead of this one.</description>
+    <lifecyclestate type="deprecated" lang="de_DE">Ersetzt durch das Addon audiodecoder.openmpt! Aber hier auch noch verwendbar.</lifecyclestate>
+    <lifecyclestate type="deprecated" lang="en_GB">Replaced by audiodecoder.openmpt addon! However, but still usable here.</lifecyclestate>
     <platform>@PLATFORM@</platform>
     <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/audiodecoder.modplug</source>

--- a/audiodecoder.modplug/addon.xml.in
+++ b/audiodecoder.modplug/addon.xml.in
@@ -13,12 +13,8 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="de_DE">Modplug Audio Decoder</summary>
     <summary lang="en_GB">Modplug Audio Decoder</summary>
-    <description lang="de_DE">Spielt MOD-Dateien und einige andere Formate ab.
-
-Es wird empfohlen, anstelle dieses Addons "OpenMPT Audio Decoder" zu verwenden.</description>
-    <description lang="en_GB">Plays MOD files and few other formats.
-
-It is recommended to use "OpenMPT Audio Decoder" addon instead of this one.</description>
+    <description lang="de_DE">Spielt MOD-Dateien und einige andere Formate ab.[CR][CR]Es wird empfohlen, anstelle dieses Addons "OpenMPT Audio Decoder" zu verwenden.</description>
+    <description lang="en_GB">Plays MOD files and few other formats.[CR][CR]It is recommended to use "OpenMPT Audio Decoder" addon instead of this one.</description>
     <lifecyclestate type="deprecated" lang="de_DE">Ersetzt durch das Addon audiodecoder.openmpt! Aber hier auch noch verwendbar.</lifecyclestate>
     <lifecyclestate type="deprecated" lang="en_GB">Replaced by audiodecoder.openmpt addon! However, but still usable here.</lifecyclestate>
     <platform>@PLATFORM@</platform>

--- a/audiodecoder.modplug/resources/language/resource.language.en_gb/strings.po
+++ b/audiodecoder.modplug/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,29 @@
+# Kodi Media Center language file
+# Addon Name: Modplug Audio Decoder
+# Addon id: audiodecoder.modplug
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: KODI Addons\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/audiodecoder.modplug/issues/\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/projects/p/kodi-addons/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "Addon Summary"
+msgid "Modplug Audio Decoder"
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "Plays MOD files and few other formats.[CR][CR]It is recommended to use \"OpenMPT Audio Decoder\" addon instead of this one."
+msgstr ""
+
+msgctxt "Addon Lifecyclestate"
+msgid "Replaced by audiodecoder.openmpt addon! However, but still usable here."
+msgstr ""

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.modplug
 Source: https://github.com/xbmc/audiodecoder.modplug
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/ModplugCodec.cpp
+++ b/src/ModplugCodec.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/ModplugCodec.h
+++ b/src/ModplugCodec.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
- set copyright year to 2021
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com
- Mark addon as deprecated as can done with https://github.com/xbmc/audiodecoder.openmpt (where supports more)